### PR TITLE
onDrag の未使用引数を修正

### DIFF
--- a/src/components/PlayerMenu.vue
+++ b/src/components/PlayerMenu.vue
@@ -76,10 +76,10 @@ function remove() {
   videoListStore.removeVideo(props.videoId);
 }
 
-function onDragstart(e: DragEvent) {
+function onDragstart(_e: DragEvent) {
   videoListStore.draggingVideoId = props.videoId;
 }
-function onDragend(e: DragEvent) {
+function onDragend(_e: DragEvent) {
   videoListStore.draggingVideoId = null;
 }
 


### PR DESCRIPTION
## 概要
`PlayerMenu.vue` のドラッグ関連ハンドラで未使用だった `e` を `_e` に変更しました。
これにより ESLint の警告が解消されます。

## テスト結果
- `pnpm run lint`
- `pnpm vitest run`
- `pnpm run type-check`
