### PR TITLE
YouTube サムネイル関数のリネーム

### DIFF
--- a/src/libs/youtube.ts
+++ b/src/libs/youtube.ts
@@ -1,7 +1,7 @@
 type YoutubeImageQuality = "" | "mq" | "hq" | "sd" | "maxres";
 
 const base = "https://i.ytimg.com/vi/";
-export function getThumnailById(id: string, quality: YoutubeImageQuality) {
+export function getThumbnailById(id: string, quality: YoutubeImageQuality) {
   return `${base}${id}/${quality}default.jpg`;
 }
 


### PR DESCRIPTION
## 変更内容
- `getThumnailById` を `getThumbnailById` にリネームしました
- 関連するインポートや呼び出しは存在しなかったため、他ファイルの変更はありません

## テスト
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm vitest run`
