### PR TITLE
YouTube URL 解析を改善

### DIFF
--- a/src/libs/youtube.test.ts
+++ b/src/libs/youtube.test.ts
@@ -8,6 +8,18 @@ describe("getYouTubeVideoId", () => {
     ).toBe("abc123");
   });
 
+  it("パラメータ付き watch URL でも ID を取得できる", () => {
+    expect(
+      getYouTubeVideoId("https://www.youtube.com/watch?v=abc123&t=30s")
+    ).toBe("abc123");
+  });
+
+  it("クエリの順序が違っても ID を取得できる", () => {
+    expect(
+      getYouTubeVideoId("https://www.youtube.com/watch?t=30s&v=abc123")
+    ).toBe("abc123");
+  });
+
   it("embed URL からIDを取得できる", () => {
     expect(
       getYouTubeVideoId("https://www.youtube.com/embed/abc123")

--- a/src/libs/youtube.ts
+++ b/src/libs/youtube.ts
@@ -5,14 +5,26 @@ export function getThumbnailById(id: string, quality: YoutubeImageQuality) {
   return `${base}${id}/${quality}default.jpg`;
 }
 
-// YouTubeのURLから動画IDを取得する
-// 標準URL: https://www.youtube.com/watch?v=videoId
-// 短縮URL: https://youtu.be/videoId
-// 埋め込みURL: https://www.youtube.com/embed/videoId
-// 短縮URL: https://www.youtube.com/v/videoId
-// ライブURL: https://www.youtube.com/live/videoId
-const videoIdPattern = /(?:v=|\/(?:embed|v|live)\/|youtu\.be\/)([0-9A-Za-z_-]+)/;
+// YouTube の URL から動画 ID を取得する
+// 標準 URL: https://www.youtube.com/watch?v=videoId
+// 短縮 URL: https://youtu.be/videoId
+// 埋め込み URL: https://www.youtube.com/embed/videoId
+// 短縮 URL: https://www.youtube.com/v/videoId
+// ライブ URL: https://www.youtube.com/live/videoId
 export function getYouTubeVideoId(url: string): string | undefined {
-  const videoId = url.match(videoIdPattern)?.[1];
-  return videoId;
+  try {
+    const parsed = new URL(url);
+    const searchId = parsed.searchParams.get("v");
+    if (searchId) return searchId;
+
+    if (parsed.hostname === "youtu.be") {
+      const id = parsed.pathname.slice(1);
+      return id || undefined;
+    }
+
+    const match = parsed.pathname.match(/\/(?:embed|v|live)\/([0-9A-Za-z_-]+)/);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
## 概要
YouTube URL から動画 ID を取得する処理を `URL` クラスで解析するように変更しました。これにより、`?t=30s` などの追加パラメータが付いていても正しく ID を取得できます。また、クエリ順序が変わっても取得できることをテストで確認しました。

## 変更点
- `src/libs/youtube.ts` を `URL` クラスを使った実装に変更
- パラメータ付き URL に対応するテストを追加

## テスト結果
- `pnpm vitest run`：成功
- `pnpm run lint`：成功
- `pnpm run type-check`：成功